### PR TITLE
Fix: Options are not passed to OpenJTalk

### DIFF
--- a/options.cc
+++ b/options.cc
@@ -81,7 +81,7 @@ constexpr option_return option(
       {
         throw Napi::TypeError::New(env, key + " is out of range."s);
       }
-      options.*m = v.As<Napi::Number>().DoubleValue();
+      options.*m = d;
     }
     else
     {

--- a/options.cc
+++ b/options.cc
@@ -81,7 +81,7 @@ constexpr option_return option(
       {
         throw Napi::TypeError::New(env, key + " is out of range."s);
       }
-      options.*m = d;
+      options.*m = v.As<Napi::Number>().DoubleValue();
     }
     else
     {
@@ -108,7 +108,7 @@ const static constexpr auto double_option_list = {
 #endif
 
 template <size_t idx, class Dst, class Src>
-inline void OptionsLoop(Dst dst, Src src)
+inline void OptionsLoop(Dst &dst, Src src)
 {
 #if __cplusplus < 201703L
   auto int_option_list = make_array(

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "node-openjtalk-binding",
-  "version": "1.2.0",
+  "version": "1.99.0",
   "main": "addon.js",
   "types": "addon.d.ts",
   "license": "(MIT OR Unlicense)",
-  "description": "Simple binding of OpenJTalk",
+  "description": "Simple binding of OpenJTalk -- forked and changed for VUTD",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tignear/node-openjtalk-binding.git"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "addon.js",
   "types": "addon.d.ts",
   "license": "(MIT OR Unlicense)",
-  "description": "Simple binding of OpenJTalk -- forked and changed for VUTD",
+  "description": "Simple binding of OpenJTalk",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/tignear/node-openjtalk-binding.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-openjtalk-binding",
-  "version": "1.99.0",
+  "version": "1.2.0",
   "main": "addon.js",
   "types": "addon.d.ts",
   "license": "(MIT OR Unlicense)",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@types/node": "^14.14.41",
     "clean-jsdoc-theme": "^3.0.9",
     "jsdoc": "^3.6.6",
-    "node-gyp": "^8.1.0",
+    "node-gyp": "^8.4.0",
     "typescript": "^4.2.3"
   },
   "binary": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-openjtalk-binding",
-  "version": "1.2.0",
+  "version": "1.2.0-vutd1",
   "main": "addon.js",
   "types": "addon.d.ts",
   "license": "(MIT OR Unlicense)",


### PR DESCRIPTION
additional_half_toneなどのオプションを渡してもOpenJTalk側の設定に反映されない問題がありましたので、options.ccを修正しました。
当方の環境ではこの修正で解決しました。

なお、package.jsonでnode-gypのバージョンを上げたのはWindows+VS2022の環境ではnode-gyp 8.2.0が動かなかったためですが、問題があればもとに戻します。