### PR TITLE
Fix options are not passed to openjtalk

### DIFF
--- a/options.cc
+++ b/options.cc
@@ -108,7 +108,7 @@ const static constexpr auto double_option_list = {
 #endif
 
 template <size_t idx, class Dst, class Src>
-inline void OptionsLoop(Dst dst, Src src)
+inline void OptionsLoop(Dst &dst, Src src)
 {
 #if __cplusplus < 201703L
   auto int_option_list = make_array(


### PR DESCRIPTION
additional_half_toneなどのオプションを渡してもOpenJTalk側の設定に反映されない問題を修正しました。
